### PR TITLE
Add Auth0 Product Security team as codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @auth0/product-security


### PR DESCRIPTION
Auth0 Product Security team maintains repo-supervisor and should be the final reviewer and approver of all pull requests.