### PR TITLE
Address various issues with the CLI script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,19 +29,25 @@ To trigger JSON format for the output report you need to set `JSON_OUTPUT=1` env
 ```bash
 → JSON_OUTPUT=1 node ./dist/cli.js ./test/fixtures/integration/dir.with.secrets/foo/ | jq
 {
-  "result": {
-    "./test/fixtures/integration/dir.with.secrets/foo//bar.js": [
-      "zJd-55qmsY6LD53CRTqnCr_g-",
-      "gm5yb-hJWRoS7ZJTi_YUj_tbU",
-      "GxC56B6x67anequGYNPsW_-TL",
-      "MLTk-BuGS8s6Tx9iK5zaL8a_W",
-      "2g877BA_TsE-WoPoWrjHah9ta"
-    ],
-    "./test/fixtures/integration/dir.with.secrets/foo//foo.json": [
-      "d7kyociU24P9hJ_sYVkqzo-kE",
-      "q28Wt3nAmLt_3NGpqi2qz-jQ7"
-    ]
-  }
+  "result": [
+    {
+      "filepath": "./test/fixtures/integration/dir.with.secrets/foo/bar.js",
+      "secrets": [
+        "zJd-55qmsY6LD53CRTqnCr_g-",
+        "gm5yb-hJWRoS7ZJTi_YUj_tbU",
+        "GxC56B6x67anequGYNPsW_-TL",
+        "MLTk-BuGS8s6Tx9iK5zaL8a_W",
+        "2g877BA_TsE-WoPoWrjHah9ta"
+      ]
+    },
+    {
+      "filepath": "./test/fixtures/integration/dir.with.secrets/foo/foo.json",
+      "secrets": [
+        "d7kyociU24P9hJ_sYVkqzo-kE",
+        "q28Wt3nAmLt_3NGpqi2qz-jQ7"
+      ]
+    }
+  ]
 }
 ```
 
@@ -63,7 +69,7 @@ As a result it should return detected secrets in JSON format:
 
 ```
 → docker run -it --rm -v /local/path/on/your/host:/opt/scan_me repo-supervisor /bin/bash -c "source ~/.bashrc && JSON_OUTPUT=1 node /opt/repo-supervisor/dist/cli.js /opt/scan_me"
-{"result":{"/opt/scan_me/bar.js":["zJd-55qmsY6LD53CRTqnCr_g-","gm5yb-hJWRoS7ZJTi_YUj_tbU","GxC56B6x67anequGYNPsW_-TL","MLTk-BuGS8s6Tx9iK5zaL8a_W","2g877BA_TsE-WoPoWrjHah9ta"],"/opt/scan_me/foo.json":["d7kyociU24P9hJ_sYVkqzo-kE","q28Wt3nAmLt_3NGpqi2qz-jQ7"]}}
+{"result":[{"filepath":"./test/fixtures/integration/dir.with.secrets/foo/bar.js","secrets":["zJd-55qmsY6LD53CRTqnCr_g-","gm5yb-hJWRoS7ZJTi_YUj_tbU","GxC56B6x67anequGYNPsW_-TL","MLTk-BuGS8s6Tx9iK5zaL8a_W","2g877BA_TsE-WoPoWrjHah9ta"]},{"filepath":"./test/fixtures/integration/dir.with.secrets/foo/foo.json","secrets":["d7kyociU24P9hJ_sYVkqzo-kE","q28Wt3nAmLt_3NGpqi2qz-jQ7"]}]}
 ```
 
 ## Setup

--- a/test/integration/src/cli.js
+++ b/test/integration/src/cli.js
@@ -1,9 +1,73 @@
 const exec = require('child_process').exec;
 
 describe('Scenario: Run tool in CLI mode to detect secrets', () => {
+  it('should print error message when no parameters were provided', (cb) => {
+    const msg = 'The directory argument was not provided.';
+
+    exec('node ./dist/cli.js', (error, stdout) => {
+      expect(error.code).to.be.equal(1);
+      expect(stdout.trim()).to.be.equal(msg);
+      cb();
+    });
+  });
+
+  it('should print error message when no parameters were provided - JSON response', (cb) => {
+    const msg = '{"result":[],"error":"The directory argument was not provided."}';
+
+    exec('JSON_OUTPUT=1 node ./dist/cli.js', (error, stdout) => {
+      expect(error.code).to.be.equal(1);
+      expect(stdout.trim()).to.be.equal(msg);
+      cb();
+    });
+  });
+
   it('should not detect secrets in empty directories', (cb) => {
     const dir = './test/fixtures/integration/dir.without.any.files.to.test';
-    const msg = 'Not detected any secrets in files.';
+    const msg = '';
+
+    exec(`node ./dist/cli.js ${dir}`, (error, stdout) => {
+      expect(error).to.be.null;
+      expect(stdout.trim()).to.be.equal(msg);
+      cb();
+    });
+  });
+
+  it('should not detect secrets in empty directories - JSON response', (cb) => {
+    const dir = './test/fixtures/integration/dir.without.any.files.to.test';
+    const msg = '{"result":[]}';
+
+    exec(`JSON_OUTPUT=1 node ./dist/cli.js ${dir}`, (error, stdout) => {
+      expect(error).to.be.null;
+      expect(stdout.trim()).to.be.equal(msg);
+      cb();
+    });
+  });
+
+  it('should not detect secrets in unsupported file formats', (cb) => {
+    const dir = './test/fixtures/integration/dir.with.secrets.not.supported.format';
+    const msg = '';
+
+    exec(`node ./dist/cli.js ${dir}`, (error, stdout) => {
+      expect(error).to.be.null;
+      expect(stdout.trim()).to.be.equal(msg);
+      cb();
+    });
+  });
+
+  it('should not detect secrets in unsupported file formats - JSON response', (cb) => {
+    const dir = './test/fixtures/integration/dir.with.secrets.not.supported.format';
+    const msg = '{"result":[]}';
+
+    exec(`JSON_OUTPUT=1 node ./dist/cli.js ${dir}`, (error, stdout) => {
+      expect(error).to.be.null;
+      expect(stdout.trim()).to.be.equal(msg);
+      cb();
+    });
+  });
+
+  it('should return an error when directory does not exist', (cb) => {
+    const dir = './this_dir_does_not_exist';
+    const msg = `"${dir}" is not a valid directory.`;
 
     exec(`node ./dist/cli.js ${dir}`, (error, stdout) => {
       expect(error.code).to.be.equal(1);
@@ -12,25 +76,11 @@ describe('Scenario: Run tool in CLI mode to detect secrets', () => {
     });
   });
 
-  it('should return an error in JSON format when triggered in JSON mode', (cb) => {
-    const dir = './test/fixtures/integration/dir.without.any.files.to.test';
-    const msg = 'Not detected any secrets in files.';
+  it('should return an error when directory does not exist - JSON response', (cb) => {
+    const dir = './this_dir_does_not_exist';
+    const msg = `{"result":[],"error":"\\"${dir}\\" is not a valid directory."}`;
 
     exec(`JSON_OUTPUT=1 node ./dist/cli.js ${dir}`, (error, stdout) => {
-      const jsonResult = JSON.parse(stdout);
-
-      expect(error.code).to.be.equal(1);
-      expect(jsonResult.error.trim()).to.be.equal(msg);
-      expect(Object.keys(jsonResult).length).to.be.equal(1);
-      cb();
-    });
-  });
-
-  it('should not detect secrets in unsupported file format', (cb) => {
-    const dir = './test/fixtures/integration/dir.with.secrets.not.supported.format';
-    const msg = 'Not detected any secrets in files.';
-
-    exec(`node ./dist/cli.js ${dir}`, (error, stdout) => {
       expect(error.code).to.be.equal(1);
       expect(stdout.trim()).to.be.equal(msg);
       cb();
@@ -40,8 +90,7 @@ describe('Scenario: Run tool in CLI mode to detect secrets', () => {
   it('should detect secrets in supported files', (cb) => {
     const dir = './test/fixtures/integration/dir.with.secrets';
     const msg =
-`===== Potential secrets have been detected: =====
-[./test/fixtures/integration/dir.with.secrets/foo/bar.js]
+`[./test/fixtures/integration/dir.with.secrets/foo/bar.js]
 >> zJd-55qmsY6LD53CRTqnCr_g-
 >> gm5yb-hJWRoS7ZJTi_YUj_tbU
 >> GxC56B6x67anequGYNPsW_-TL
@@ -59,9 +108,9 @@ describe('Scenario: Run tool in CLI mode to detect secrets', () => {
     });
   });
 
-  it('should detect secrets in supported files when in JSON mode', (cb) => {
+  it('should detect secrets in supported files - JSON response', (cb) => {
     const dir = './test/fixtures/integration/dir.with.secrets';
-    const msg = '{"result":{"./test/fixtures/integration/dir.with.secrets/foo/bar.js":["zJd-55qmsY6LD53CRTqnCr_g-","gm5yb-hJWRoS7ZJTi_YUj_tbU","GxC56B6x67anequGYNPsW_-TL","MLTk-BuGS8s6Tx9iK5zaL8a_W","2g877BA_TsE-WoPoWrjHah9ta"],"./test/fixtures/integration/dir.with.secrets/foo/foo.json":["d7kyociU24P9hJ_sYVkqzo-kE","q28Wt3nAmLt_3NGpqi2qz-jQ7"]}}';
+    const msg = '{"result":[{"filepath":"./test/fixtures/integration/dir.with.secrets/foo/bar.js","secrets":["zJd-55qmsY6LD53CRTqnCr_g-","gm5yb-hJWRoS7ZJTi_YUj_tbU","GxC56B6x67anequGYNPsW_-TL","MLTk-BuGS8s6Tx9iK5zaL8a_W","2g877BA_TsE-WoPoWrjHah9ta"]},{"filepath":"./test/fixtures/integration/dir.with.secrets/foo/foo.json","secrets":["d7kyociU24P9hJ_sYVkqzo-kE","q28Wt3nAmLt_3NGpqi2qz-jQ7"]}]}';
 
     exec(`JSON_OUTPUT=1 node ./dist/cli.js ${dir}`, (error, stdout) => {
       expect(error).to.be.null;


### PR DESCRIPTION
- Do not throw an error when secrets were not found, refs #5
- Return empty result set when no secrets were found
- Throw an error only if error occurred:
	- Directory not found
	- CLI arguments not provided
- Improve semantics on the JSON output:

OLD:
```
{
  "result": {
    "./src/filters/entropy.meter/pre.filters/css.selectors.js": [
      "(^([#.][a-z0-9_-]+){1,}$)|",
      "(^([#.]?[a-z0-9_-]+>){1,}([#.]?[a-z0-9_-]+)$)|"
    ]
  }
}
```

NEW:
```
{
  "result": [
    {
      "filepath": "./src/filters/entropy.meter/pre.filters/css.selectors.js",
      "secrets": [
        "(^([#.][a-z0-9_-]+){1,}$)|",
        "(^([#.]?[a-z0-9_-]+>){1,}([#.]?[a-z0-9_-]+)$)|"
      ]
    }
  ]
}
```

This PR breaks the compatibility since it changes the output format for CLI tool in JSON mode. It's going to be released as the minor version update.