### PR TITLE
Fixes an e-mail address detection in pre-filters

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "repo-supervisor",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "repo-supervisor",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Scan your code for security misconfigurations, search for passwords and secrets.",
   "main": "src/index.js",
   "scripts": {

--- a/src/filters/entropy.meter/pre.filters/email.addresses.js
+++ b/src/filters/entropy.meter/pre.filters/email.addresses.js
@@ -1,4 +1,4 @@
 /**
  * Skip all email addresses because they generate high entropy results.
  */
-module.exports = s => !s.match(/^[a-z0-9+_.-]+@[a-z._-]+\.[a-z]+$/i);
+module.exports = s => !s.match(/^[\w\d+.-]+@[\w\d.-]+\.[\w]+$/i);

--- a/test/fixtures/unit/src/filters/entropy.meter/pre.filters/email.addresses.json
+++ b/test/fixtures/unit/src/filters/entropy.meter/pre.filters/email.addresses.json
@@ -7,6 +7,10 @@
     "john.doe+test@example.museum",
     "john.doe_test+foobar@example.com",
     "john@example.museum",
-    "john@doe.example.com"
+    "john@doe.example.com",
+    "no-reply@example0.com",
+    "test1@example2.com",
+    "test2@example-1-2.com",
+    "test@example.1.2.com"
   ]
 }


### PR DESCRIPTION
Fix e-mail validation to allow domains with numbers to be detected as valid domains. Previously valid e-mail like `foo-bar@example1.com` was detected as secret and not detected as e-mail.

The purpose of e-mail pre-filter is to detect valid e-mail address and then skip it while detecting secrets. Otherwise it would detect e-mails as secrets since those could have high entropy value.

**Changes:**
- Replace `[a-z_]` with `\w`
- Replace `[0-9]` with `\d`
- Allow e-mail domains to have a number in it