### PR TITLE
fix missing zip package in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ENV DEBIAN_FRONTEND noninteractive
 # Install packages
 RUN apt-get update -qq && apt-get install -y \
     locales \
+    zip \
     -qq
 
 # Generate locales


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Fix for missing Zip package in Dockerfile.
Docker image successfully builds with this package included.

### References

https://github.com/auth0/repo-supervisor/issues/41

### Testing

Build the docker image with the version 3.0.0 changes and include the Zip package as i have done.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
