### PR TITLE
Add support for yaml files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ENV DEBIAN_FRONTEND noninteractive
 # Install packages
 RUN apt-get update -qq && apt-get install -y \
     locales \
+    zip \
     -qq
 
 # Generate locales

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Repo-supervisor aims to decrease the number of false positives as much as possib
 
 - JSON (.json)
 - JavaScript (.js)
+- YAML (.yaml)
 
 We plan to add new file types in the future. Read a documentation on [how to add a new file type](docs/add.new.file.type.md) to learn more.
 

--- a/config/filters.json
+++ b/config/filters.json
@@ -23,7 +23,7 @@
     }
   },
   {
-    "ext": ".yaml",
+    "ext": [".yaml", ".yml"],
     "filters": ["entropy.meter/index.js"],
     "parser": {
       "module": "tokenizer/yaml/index.js",

--- a/config/filters.json
+++ b/config/filters.json
@@ -21,5 +21,13 @@
         "checkObjectValues": true
       }
     }
+  },
+  {
+    "ext": ".yaml",
+    "filters": ["entropy.meter/index.js"],
+    "parser": {
+      "module": "tokenizer/yaml/index.js",
+      "config": {}
+    }
   }
 ]

--- a/config/main.json
+++ b/config/main.json
@@ -3,7 +3,7 @@
   "githubUrl": "https://github.com",
   "pullRequests": {
     "allowedActions": ["opened", "reopened", "synchronize"],
-    "allowedExtensions": [".js", ".json", ".yaml"],
+    "allowedExtensions": [".js", ".json", ".yaml", ".yml"],
     "excludedPaths": ["^test"],
     "updateGithubStatus": true
   },

--- a/config/main.json
+++ b/config/main.json
@@ -3,7 +3,7 @@
   "githubUrl": "https://github.com",
   "pullRequests": {
     "allowedActions": ["opened", "reopened", "synchronize"],
-    "allowedExtensions": [".js", ".json"],
+    "allowedExtensions": [".js", ".json", ".yaml"],
     "excludedPaths": ["^test"],
     "updateGithubStatus": true
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1205,7 +1205,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -2770,8 +2769,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
       "version": "1.1.0",
@@ -4390,7 +4388,6 @@
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -6301,8 +6298,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.16.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "an-array-of-english-words": "^1.3.1",
     "handlebars": "^4.1.2",
     "handlebars-loader": "^1.7.1",
+    "js-yaml": "^3.13.1",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.15",
     "request": "^2.88.0",

--- a/src/parser/tokenizer/yaml/index.js
+++ b/src/parser/tokenizer/yaml/index.js
@@ -6,26 +6,24 @@ const toArray = (obj, arr) => {
     Object.keys(obj).forEach((key) => {
       const value = obj[key];
       if (value !== null && typeof value === 'object') {
-        toArray(value, arr)
+        toArray(value, arr);
       } else if (value) {
         arr.push(value.toString());
-        }
+      }
     });
   }
   return arr;
 };
 
-module.exports = (content, config) => {
+module.exports = (content) => {
   const result = [];
   let object;
-
-  if (config) {};
 
   try {
     object = yaml.safeLoad(content);
   } catch (e) {
-      return [];
-    }
+    return [];
+  }
 
   toArray(object, result);
 

--- a/src/parser/tokenizer/yaml/index.js
+++ b/src/parser/tokenizer/yaml/index.js
@@ -1,16 +1,22 @@
 const yaml = require('js-yaml');
 const { flatten, uniq } = require('lodash');
 
-const toArray = (obj, arr) => {
-  if (obj) {
+// Set recursion limit
+const maxDepth = 50;
+
+const toArray = (obj, arr, depth = 0) => {
+  if (obj && depth < maxDepth) {
+    depth++;
     Object.keys(obj).forEach((key) => {
       const value = obj[key];
       if (value !== null && typeof value === 'object') {
-        toArray(value, arr);
+        toArray(value, arr, depth);
       } else if (value) {
         arr.push(value.toString());
       }
     });
+  } else if (depth >= maxDepth) {
+    throw new Error(`Maximum object depth (${maxDepth}) exceeded.`);
   }
   return arr;
 };

--- a/src/parser/tokenizer/yaml/index.js
+++ b/src/parser/tokenizer/yaml/index.js
@@ -1,0 +1,33 @@
+const yaml = require('js-yaml');
+const { flatten, uniq } = require('lodash');
+
+const toArray = (obj, arr) => {
+  if (obj) {
+    Object.keys(obj).forEach((key) => {
+      const value = obj[key];
+      if (value !== null && typeof value === 'object') {
+        toArray(value, arr)
+      } else if (value) {
+        arr.push(value.toString());
+        }
+    });
+  }
+  return arr;
+};
+
+module.exports = (content, config) => {
+  const result = [];
+  let object;
+
+  if (config) {};
+
+  try {
+    object = yaml.safeLoad(content);
+  } catch (e) {
+      return [];
+    }
+
+  toArray(object, result);
+
+  return uniq(flatten(result));
+};

--- a/test/fixtures/integration/dir.with.secrets/foo/foo.yaml
+++ b/test/fixtures/integration/dir.with.secrets/foo/foo.yaml
@@ -1,0 +1,15 @@
+spec:
+  containers:
+    - name: test-container
+      image: test.test.io/test:0.3.2
+      command: [ "sh", "-c", export, API_KEY=iaCELgL.0imfnc4mVLWwsAawjYr4Rx-Bf50DDptlz]
+      args:
+      - while true; do
+          echo -en '\n';
+        done;
+      env:
+        - name: USER
+          value: "test_user"
+        - name: PASSWORD
+          value: "c0NhbGVpbzEyMw==83bnd2!adfiu3"
+  restartPolicy: Never

--- a/test/fixtures/integration/dir.with.secrets/foo/foo.yml
+++ b/test/fixtures/integration/dir.with.secrets/foo/foo.yml
@@ -1,0 +1,15 @@
+spec:
+  containers:
+    - name: test-container
+      image: test.test.io/test:0.3.2
+      command: [ "sh", "-c", export, USER_ID=984267C934L692S8109S270]
+      args:
+      - while true; do
+          echo -en '\n';
+        done;
+      env:
+        - name: DB_USER
+          value: "test-user"
+        - name: DB_PASSWORD
+          value: "LE73!jd8DNo$%Mn!kSN"
+  restartPolicy: Never

--- a/test/integration/src/cli.js
+++ b/test/integration/src/cli.js
@@ -109,7 +109,15 @@ describe('Scenario: Run tool in CLI mode to detect secrets', () => {
 
 [./test/fixtures/integration/dir.with.secrets/foo/foo.json]
 >> d7kyociU24P9hJ_sYVkqzo-kE
->> q28Wt3nAmLt_3NGpqi2qz-jQ7`;
+>> q28Wt3nAmLt_3NGpqi2qz-jQ7
+
+[./test/fixtures/integration/dir.with.secrets/foo/foo.yaml]
+>> API_KEY=iaCELgL.0imfnc4mVLWwsAawjYr4Rx-Bf50DDptlz
+>> c0NhbGVpbzEyMw==83bnd2!adfiu3
+
+[./test/fixtures/integration/dir.with.secrets/foo/foo.yml]
+>> USER_ID=984267C934L692S8109S270
+>> LE73!jd8DNo$%Mn!kSN`;
 
     exec(`${execCMD} ${dir}`, (error, stdout) => {
       expect(error).to.be.null;
@@ -120,7 +128,7 @@ describe('Scenario: Run tool in CLI mode to detect secrets', () => {
 
   it('should detect secrets in supported files - JSON response', (cb) => {
     const dir = './test/fixtures/integration/dir.with.secrets';
-    const msg = '{"result":[{"filepath":"./test/fixtures/integration/dir.with.secrets/foo/bar.js","secrets":["zJd-55qmsY6LD53CRTqnCr_g-","gm5yb-hJWRoS7ZJTi_YUj_tbU","GxC56B6x67anequGYNPsW_-TL","MLTk-BuGS8s6Tx9iK5zaL8a_W","2g877BA_TsE-WoPoWrjHah9ta"]},{"filepath":"./test/fixtures/integration/dir.with.secrets/foo/foo.json","secrets":["d7kyociU24P9hJ_sYVkqzo-kE","q28Wt3nAmLt_3NGpqi2qz-jQ7"]}]}';
+    const msg = '{"result":[{"filepath":"./test/fixtures/integration/dir.with.secrets/foo/bar.js","secrets":["zJd-55qmsY6LD53CRTqnCr_g-","gm5yb-hJWRoS7ZJTi_YUj_tbU","GxC56B6x67anequGYNPsW_-TL","MLTk-BuGS8s6Tx9iK5zaL8a_W","2g877BA_TsE-WoPoWrjHah9ta"]},{"filepath":"./test/fixtures/integration/dir.with.secrets/foo/foo.json","secrets":["d7kyociU24P9hJ_sYVkqzo-kE","q28Wt3nAmLt_3NGpqi2qz-jQ7"]},{"filepath":"./test/fixtures/integration/dir.with.secrets/foo/foo.yaml","secrets":["API_KEY=iaCELgL.0imfnc4mVLWwsAawjYr4Rx-Bf50DDptlz","c0NhbGVpbzEyMw==83bnd2!adfiu3"]},{"filepath":"./test/fixtures/integration/dir.with.secrets/foo/foo.yml","secrets":["USER_ID=984267C934L692S8109S270","LE73!jd8DNo$%Mn!kSN"]}]}';
 
     exec(`${execCMD} ${dir}`, options, (error, stdout) => {
       expect(error).to.be.null;


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Adds support for yaml file type.
Uses the js-yaml library to parse yaml then returns unique values of all nested objects.
https://www.npmjs.com/package/js-yaml

The js-yaml safeLoad method is also safe for untrusted data.

### Testing

Pass any path containing a yaml file when running the app

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
