### PR TITLE
Process nested json objects and fix a bug in json tokenizer

### DIFF
--- a/config/filters.json
+++ b/config/filters.json
@@ -18,7 +18,8 @@
       "module": "tokenizer/json/index.js",
       "config": {
         "checkObjectKeys": true,
-        "checkObjectValues": true
+        "checkObjectValues": true,
+        "maxAllowedDepth": 10
       }
     }
   },

--- a/test/integration/src/cli.js
+++ b/test/integration/src/cli.js
@@ -100,7 +100,7 @@ describe('Scenario: Run tool in CLI mode to detect secrets', () => {
   it('should detect secrets in supported files', (cb) => {
     const dir = './test/fixtures/integration/dir.with.secrets';
     const msg =
-`[./test/fixtures/integration/dir.with.secrets/foo/bar.js]
+      `[./test/fixtures/integration/dir.with.secrets/foo/bar.js]
 >> zJd-55qmsY6LD53CRTqnCr_g-
 >> gm5yb-hJWRoS7ZJTi_YUj_tbU
 >> GxC56B6x67anequGYNPsW_-TL
@@ -108,8 +108,8 @@ describe('Scenario: Run tool in CLI mode to detect secrets', () => {
 >> 2g877BA_TsE-WoPoWrjHah9ta
 
 [./test/fixtures/integration/dir.with.secrets/foo/foo.json]
->> d7kyociU24P9hJ_sYVkqzo-kE
 >> q28Wt3nAmLt_3NGpqi2qz-jQ7
+>> d7kyociU24P9hJ_sYVkqzo-kE
 
 [./test/fixtures/integration/dir.with.secrets/foo/foo.yaml]
 >> API_KEY=iaCELgL.0imfnc4mVLWwsAawjYr4Rx-Bf50DDptlz
@@ -128,7 +128,7 @@ describe('Scenario: Run tool in CLI mode to detect secrets', () => {
 
   it('should detect secrets in supported files - JSON response', (cb) => {
     const dir = './test/fixtures/integration/dir.with.secrets';
-    const msg = '{"result":[{"filepath":"./test/fixtures/integration/dir.with.secrets/foo/bar.js","secrets":["zJd-55qmsY6LD53CRTqnCr_g-","gm5yb-hJWRoS7ZJTi_YUj_tbU","GxC56B6x67anequGYNPsW_-TL","MLTk-BuGS8s6Tx9iK5zaL8a_W","2g877BA_TsE-WoPoWrjHah9ta"]},{"filepath":"./test/fixtures/integration/dir.with.secrets/foo/foo.json","secrets":["d7kyociU24P9hJ_sYVkqzo-kE","q28Wt3nAmLt_3NGpqi2qz-jQ7"]},{"filepath":"./test/fixtures/integration/dir.with.secrets/foo/foo.yaml","secrets":["API_KEY=iaCELgL.0imfnc4mVLWwsAawjYr4Rx-Bf50DDptlz","c0NhbGVpbzEyMw==83bnd2!adfiu3"]},{"filepath":"./test/fixtures/integration/dir.with.secrets/foo/foo.yml","secrets":["USER_ID=984267C934L692S8109S270","LE73!jd8DNo$%Mn!kSN"]}]}';
+    const msg = '{"result":[{"filepath":"./test/fixtures/integration/dir.with.secrets/foo/bar.js","secrets":["zJd-55qmsY6LD53CRTqnCr_g-","gm5yb-hJWRoS7ZJTi_YUj_tbU","GxC56B6x67anequGYNPsW_-TL","MLTk-BuGS8s6Tx9iK5zaL8a_W","2g877BA_TsE-WoPoWrjHah9ta"]},{"filepath":"./test/fixtures/integration/dir.with.secrets/foo/foo.json","secrets":["q28Wt3nAmLt_3NGpqi2qz-jQ7","d7kyociU24P9hJ_sYVkqzo-kE"]},{"filepath":"./test/fixtures/integration/dir.with.secrets/foo/foo.yaml","secrets":["API_KEY=iaCELgL.0imfnc4mVLWwsAawjYr4Rx-Bf50DDptlz","c0NhbGVpbzEyMw==83bnd2!adfiu3"]},{"filepath":"./test/fixtures/integration/dir.with.secrets/foo/foo.yml","secrets":["USER_ID=984267C934L692S8109S270","LE73!jd8DNo$%Mn!kSN"]}]}';
 
     exec(`${execCMD} ${dir}`, options, (error, stdout) => {
       expect(error).to.be.null;

--- a/test/issues/issue-007.js
+++ b/test/issues/issue-007.js
@@ -5,7 +5,7 @@ const config = { checkObjectKeys: true, checkObjectValues: true };
 function test() {
   it('[Issue #007] Should not fail on JSON with "toString" key', () => {
     const objectA = { builtin: { toString: true } };
-    const objectB = ['builtin', '[object Object]'];
+    const objectB = ['builtin', 'toString', 'true'];
     const result = tokenizer(JSON.stringify(objectA), config);
 
     expect(JSON.stringify(result)).to.be.equal(JSON.stringify(objectB));

--- a/test/issues/issue-065.js
+++ b/test/issues/issue-065.js
@@ -1,0 +1,78 @@
+/* eslint-disable max-len */
+// Issue: https://github.com/auth0/repo-supervisor/issues/65
+const tokenizer = require(`${global.srcPath}/parser/tokenizer/json/index.js`);
+const objectA = {
+  a: 1,
+  b: 'test',
+  c: {
+    aa: 2,
+    bb: 'test2',
+    cc: {
+      aaa: 3,
+      bbb: 'test3',
+      ccc: {
+        aaaa: 4,
+        bbbb: 'test4',
+        cccc: {},
+        dddd: ['foobar', 44, {
+          foobar4: 444,
+          foobar__44: ['foobar_44']
+        }]
+      },
+      ddd: ['foobar', 33, {
+        foobar3: 333,
+        foobar__33: ['foobar_33']
+      }]
+    },
+    dd: ['foobar', 22, {
+      foobar2: 222,
+      foobar__22: ['foobar_22']
+    }]
+  },
+  d: ['foobar', 1, {
+    foobar1: 111,
+    foobar__11: ['foobar_11']
+  }]
+};
+const objectB = ['a', '1', 'b', 'test', 'c', 'aa', '2', 'bb', 'test2', 'cc', 'aaa', '3', 'bbb', 'test3', 'ccc', 'aaaa', '4', 'bbbb', 'test4', 'cccc', 'dddd', '0', 'foobar', '44', 'foobar4', '444', 'foobar__44', 'foobar_44', 'ddd', '33', 'foobar3', '333', 'foobar__33', 'foobar_33', 'dd', '22', 'foobar2', '222', 'foobar__22', 'foobar_22', 'd', 'foobar1', '111', 'foobar__11', 'foobar_11'];
+
+function test() {
+  it('[Issue #065] Should process nested JSON object and return all keys and values', () => {
+    const config = { checkObjectKeys: true, checkObjectValues: true, maxAllowedDepth: 100 };
+    const result = tokenizer(JSON.stringify(objectA), config);
+
+    expect(JSON.stringify(result)).to.be.equal(JSON.stringify(objectB));
+  });
+
+  it('[Issue #065] Should process nested JSON object with max allowed depth limit', () => {
+    const fixtures = [
+      {
+        config: { checkObjectKeys: true, checkObjectValues: true, maxAllowedDepth: 1 },
+        result: ['a', '1', 'b', 'test', 'c', 'd']
+      },
+      {
+        config: { checkObjectKeys: true, checkObjectValues: true, maxAllowedDepth: 3 },
+        result: ['a', '1', 'b', 'test', 'c', 'aa', '2', 'bb', 'test2', 'cc', 'aaa', '3', 'bbb', 'test3', 'ccc', 'ddd', 'dd', 'd', '0', 'foobar']
+      },
+      {
+        config: { checkObjectKeys: true, checkObjectValues: true, maxAllowedDepth: 7 },
+        result: ['a', '1', 'b', 'test', 'c', 'aa', '2', 'bb', 'test2', 'cc', 'aaa', '3', 'bbb', 'test3', 'ccc', 'aaaa', '4', 'bbbb', 'test4', 'cccc', 'dddd', '0', 'foobar', '44', 'foobar4', '444', 'foobar__44', 'ddd', '33', 'foobar3', '333', 'foobar__33', 'foobar_33', 'dd', '22', 'foobar2', '222', 'foobar__22', 'foobar_22', 'd', 'foobar1', '111', 'foobar__11', 'foobar_11']
+      },
+      {
+        config: { checkObjectKeys: true, checkObjectValues: true, maxAllowedDepth: 8 },
+        result: objectB
+      },
+      {
+        config: { checkObjectKeys: true, checkObjectValues: true, maxAllowedDepth: 100 },
+        result: objectB
+      }
+    ];
+
+    fixtures.forEach((fixture) => {
+      const result = tokenizer(JSON.stringify(objectA), fixture.config);
+      expect(JSON.stringify(result)).to.be.equal(JSON.stringify(fixture.result), `Failed for the nested level of ${fixture.config.maxAllowedDepth}`);
+    });
+  });
+}
+
+module.exports = test;


### PR DESCRIPTION
### Description

The purpose of JSON tokenizer is to process `.json` files and parse JSON objects to extract strings. As a result it allows to measure an entropy of each string.

There is a bug that instead of returning separate strings from a json object, would return a single string with concatenated values. Therefore, it didn't support nested objects too well.

### What changed?

- JSON tokenizer was updated to support nested objects with recursion
- The hard limit for max depth in parsing nested objects is set to 10, but is configurable in the settings
- It resolves a bug reported in #64 

### References

- It fixes #64 

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
