### PR TITLE
Decreasing the false positive ratio with new pre-filters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,12 @@ ENV LANG C.UTF-8
 ENV LANGUAGE C.UTF-8
 ENV LC_ALL C.UTF-8
 
-# Setting up terminal preferences
+# Add files into the container
 ADD ./ /opt/repo-supervisor
 
 # Install node version manager
-RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash
+RUN /bin/bash -c "touch ~/.bashrc"
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.36.0/install.sh | bash
 RUN /bin/bash -c "source ~/.bashrc && nvm install 10"
 
 # Build scripts

--- a/bin/wt
+++ b/bin/wt
@@ -1,1 +1,0 @@
-../node_modules/.bin/wt

--- a/config/filters/entropy.meter.json
+++ b/config/filters/entropy.meter.json
@@ -4,6 +4,7 @@
   },
   "preFilters": [
     "whitelist.js",
+    "non.printable.characters.js",
     "authentication.urls.js",
     "css.selectors.js",
     "email.addresses.js",

--- a/config/filters/entropy.meter.json
+++ b/config/filters/entropy.meter.json
@@ -18,11 +18,18 @@
     "entropyPrecision": 4,
     "maxAllowedEntropy": 4,
     "preFilters": {
+      "dictionaryWords": {
+        "requiredDictionaryWordsPercent": 0.3
+      },
       "skipPrefixes": [
-        "test-", "foobar-"
+        "test-",
+        "foobar-"
       ],
       "whitelist": [
-        "test", "foobar", "foo", "bar"
+        "test",
+        "foobar",
+        "foo",
+        "bar"
       ],
       "minStringLength": 15
     }

--- a/config/main.json
+++ b/config/main.json
@@ -16,7 +16,7 @@
     }
   },
   "cli": {
-    "excludedPaths": ["^test", "^[.]git$"],
+    "excludedPaths": ["^test", "^[.]git$", "^dist"],
     "messages": {
       "invalidArguments": "Invalid number of arguments.",
       "invalidDirectory": "\"%s\" is not a valid directory."

--- a/config/main.json
+++ b/config/main.json
@@ -36,7 +36,7 @@
     "jwtTokenNotProvided": "JWT_SECRET is not set",
     "invalidReportID": "Report not found, invalid ID"
   },
-  "runTriggers": true,
+  "runTriggers": false,
   "triggerTextFormat": "mrkdwn",
   "triggerMessages": {
     "falsePositiveReported": ":warning: False positive reported (%s): %s",

--- a/src/filters/entropy.meter/pre.filters/dictionary.words.js
+++ b/src/filters/entropy.meter/pre.filters/dictionary.words.js
@@ -1,12 +1,11 @@
 'use strict';
 
 const dictionary = new Set(require('an-array-of-english-words'));
-
-const requiredPercent = 0.35;
+const config = require('./../../../../config/filters/entropy.meter.json');
 
 function splitIntoWords(str) {
   // Hyphens, underscores, commas, stops and numbers
-  str = str.replace(/[-_,.]/g, ' ')
+  str = str.replace(/[-_,.|]/g, ' ')
     .replace(/([0-9]+)/g, ' $1 ');
 
   // camelCase
@@ -37,5 +36,5 @@ module.exports = function filterCamelCaseWord(str) {
   );
 
   const percent = wordCount / words.length;
-  return percent < requiredPercent;
+  return percent < config.options.preFilters.dictionaryWords.requiredDictionaryWordsPercent;
 };

--- a/src/filters/entropy.meter/pre.filters/non.printable.characters.js
+++ b/src/filters/entropy.meter/pre.filters/non.printable.characters.js
@@ -1,0 +1,10 @@
+/**
+ * Skip all strings containing non ASCII characters.
+ *
+ * Space " " (0x20) character is the first printable one in the ASCII table.
+ * The last printable one is tilde "~" (0x7E). This is the reason for defined
+ * range in the regular expression. We do not take UTF characters into account
+ * as those are not going to be a part of secret in vast majority of cases.
+ * It allows to reduce false positives significantly.
+ */
+module.exports = s => !s.match(/[^ -~]+/);

--- a/test/fixtures/unit/src/filters/entropy.meter/pre.filters/dictionary.words.json
+++ b/test/fixtures/unit/src/filters/entropy.meter/pre.filters/dictionary.words.json
@@ -30,7 +30,7 @@
     "Llxr8IOO5UucEqB8fng",
     "RNf_4j3t5ki2Qj-wnWjsNg",
     "RNf_4jdttki2Qj-wnwjsng",
-    "almost-ryeal-byet-noeut-there-jyet",
+    "almostt-ryeal-byet-noeut-there-jyet",
     "c6790fe8ae230ecce7fa521079e4ed08"
   ]
 }

--- a/test/fixtures/unit/src/filters/entropy.meter/pre.filters/non.printable.characters.json
+++ b/test/fixtures/unit/src/filters/entropy.meter/pre.filters/non.printable.characters.json
@@ -1,0 +1,14 @@
+{
+  "printableASCIIcharacters": [
+    "0161ee9477df7286674533cd75b3a3f969b53be706cc046aed8fe1bcb3ba0ace",
+    "[fY28j7'Vb,(sWALk8NKH:ut^=N>rpP",
+    "9jFgE7<[[R]_~uVB!V3YC_#*994Vjm#,p5Bmz>%8Tm/.r#/ye!X$B7,A9?6{N=[eemCr",
+    "3NTtSeDPjnkx3jxrcN7vTQ9fj3dZjxJNWYDefZKfkvQ3"
+  ],
+  "nonPrintableASCIIcharacters": [
+    "0161ee9477⚠️df7286674533cd75b3a3f969b53be706cc046aed8fe1bcb3ba0ace",
+    "[fY28j7'Vb,(sWALk🐛8NKH:ut^=N>rpP",
+    "9jFgE7<[[R]_🐞~uVB!V3YC_#*994Vjm#,p5Bmz>%8Tm/.r#/ye!X$B7,A9?6{N=[eemCr",
+    "3NTtSeDPjnkx3jxrcN7vTQ9fj3文dZjxJNWYDefZKfkvQ3"
+  ]
+}

--- a/test/unit/src/filters/entropy.meter/pre.filters/non.printable.characters.js
+++ b/test/unit/src/filters/entropy.meter/pre.filters/non.printable.characters.js
@@ -1,0 +1,16 @@
+const filter = require(`${global.srcPath}/filters/entropy.meter/pre.filters/non.printable.characters.js`);
+const fixtures = global.getFixtures(__filename);
+
+describe('Pre filter -> Non-printable characters', () => {
+  it('should skip all non ASCII printable characters', () => {
+    fixtures.nonPrintableASCIIcharacters.forEach((words) => {
+      expect(filter(words), words).to.be.equal(false);
+    });
+  });
+
+  it('should allow all non ASCII printable characters', () => {
+    fixtures.printableASCIIcharacters.forEach((words) => {
+      expect(filter(words), words).to.be.equal(true);
+    });
+  });
+});


### PR DESCRIPTION
### Description

This PR is meant to reduce the number of false positives. Multiple improvements include:

- Ignoring non-printable ASCII characters.
- Reducing 35% of words detected in a secret to 30%.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
